### PR TITLE
Improve crash handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Reimplement afl-cmin in python. Use less memory, less disk space, and faster.
  - Support the same command line flags as original afl-cmin.
  - dedup by hash of file content in the beginning.
  - `-i DIR` can be specified multiple times. Also support globbing.
+ - `-c DIR` to copy detected crashes (deduplicated by hash) into `DIR`.
  - `-w WORKERS` to specify number of workers.
  - `--as_queue` output filename like `id:000001,hash:value`.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Reimplement afl-cmin in python. Use less memory, less disk space, and faster.
  - Support the same command line flags as original afl-cmin.
  - dedup by hash of file content in the beginning.
  - `-i DIR` can be specified multiple times. Also support globbing.
- - `-c DIR` to copy detected crashes (deduplicated by hash) into `DIR`.
+ - `--crash-dir DIR` to copy detected crashes (deduplicated by hash) into `DIR`.
  - `-w WORKERS` to specify number of workers.
  - `--as_queue` output filename like `id:000001,hash:value`.
 

--- a/afl-cmin.py
+++ b/afl-cmin.py
@@ -81,8 +81,6 @@ def init():
     logging.basicConfig(level=log_level, format='%(asctime)s - %(levelname)s - %(message)s')
     logger = logging.getLogger(__name__)
 
-    os.environ['AFL_CMIN_ALLOW_ANY'] = '1'
-
     if args.stdin_file and args.workers > 1:
         logger.error('-f is only supported with one worker (-w 1)')
         sys.exit(1)
@@ -157,10 +155,13 @@ def afl_showmap(input_path, first=False):
 
     if first:
         logger.debug('run command line: %s', subprocess.list2cmdline(cmd))
+        env = env.copy()
+        env['AFL_CMIN_ALLOW_ANY'] = '1'
+
     if input_from_file:
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, bufsize=1048576)
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, env=env, bufsize=1048576)
     else:
-        p = subprocess.Popen(cmd, stdin=file(input_path), stdout=subprocess.PIPE, bufsize=1048576)
+        p = subprocess.Popen(cmd, stdin=file(input_path), stdout=subprocess.PIPE, env=env, bufsize=1048576)
     out = p.stdout.read()
     p.wait()
     #out = p.communicate()[0]

--- a/afl-cmin.py
+++ b/afl-cmin.py
@@ -56,7 +56,7 @@ group.add_argument('-Q', dest='qemu_mode', action='store_true', default=False,
         help='use binary-only instrumentation (QEMU mode)')
 
 group = parser.add_argument_group('Minimization settings')
-group.add_argument('-c', dest='crash_dir', metavar='dir', default=None,
+group.add_argument('--crash-dir', dest='crash_dir', metavar='dir', default=None,
         help='move crashes to a separate dir, always deduplicated')
 group.add_argument('-C', dest='crash_only', action='store_true',
         help='keep crashing inputs, reject everything else')

--- a/afl-cmin.py
+++ b/afl-cmin.py
@@ -332,7 +332,12 @@ def main():
     if args.crash_dir:
         logger.info('Saving crashes to %s', args.crash_dir)
         crash_files = [files[c] for c in crashes]
-        crash_files, hashmap = dedup(crash_files)
+
+        if args.no_dedup:
+            # Unless we deduped previously, we have to dedup the crash files
+            # now.
+            crash_files, hashmap = dedup(crash_files)
+
         for crash_path in crash_files:
             fn = base64.b16encode(hashmap[crash_path]).lower()
             output_path = os.path.join(args.crash_dir, fn)

--- a/afl-cmin.py
+++ b/afl-cmin.py
@@ -348,7 +348,9 @@ def main():
                 try:
                     shutil.copy(crash_path, output_path)
                 except shutil.Error:
-                    # files are the same; do nothing since we already have it
+                    # This error happens when src and dest are hardlinks of the
+                    # same file. We have nothing to do in this case, but handle
+                    # it gracefully.
                     pass
 
     if count == 1:

--- a/afl-cmin.py
+++ b/afl-cmin.py
@@ -175,7 +175,9 @@ def afl_showmap(input_path, first=False):
 
     # return code of afl-showmap is child_crashed * 2 + child_timed_out where
     # child_crashed and child_timed_out are either 0 or 1
-    return (a, p.returncode in [2, 3])
+    crashed = p.returncode in [2, 3]
+
+    return a, crashed
 
 class Worker(multiprocessing.Process):
     def __init__(self, q_in, p_out, r_out):

--- a/afl-cmin.py
+++ b/afl-cmin.py
@@ -141,7 +141,7 @@ def afl_showmap(input_path, first=False):
             '-t', str(args.time_limit),
             '-o', '-',
             '-Z']
-    env = os.environ
+    env = os.environ.copy()
 
     if args.qemu_mode:
         cmd += ['-Q']
@@ -161,7 +161,6 @@ def afl_showmap(input_path, first=False):
 
     if first:
         logger.debug('run command line: %s', subprocess.list2cmdline(cmd))
-        env = env.copy()
         env['AFL_CMIN_ALLOW_ANY'] = '1'
 
     if input_from_file:


### PR DESCRIPTION
This PR improves handling of crashing test cases in the corpus in three ways:
  *  Sets `AFL_CMIN_ALLOW_ANY` only during the initial test run, improving compatibility with the original afl-cmin. It also enables the `-C` flag to work as intended.
  * Detects and reports number of crashes encountered during corpus minimization.
  * Adds a `-c <dir>` flag to copy detected crashes into `<dir>`.